### PR TITLE
Modify ViewBuilder node collection to take into account nested children and useUnmergedTree param

### DIFF
--- a/compose/src/main/kotlin/io/github/kakaocup/compose/node/KNode.kt
+++ b/compose/src/main/kotlin/io/github/kakaocup/compose/node/KNode.kt
@@ -7,7 +7,7 @@ import io.github.kakaocup.compose.screen.ComposeScreen
 open class KNode : KDSL<KNode>, NodeAssertions, NodeActions, TextActions {
     override val nodeInteraction: SemanticsNodeInteraction
 
-    constructor(composeScreen: ComposeScreen<*>, function: ViewBuilder.() -> Unit) {
-        nodeInteraction = ViewBuilder(composeScreen.composeTestRule).apply(function).nodeInteraction
+    constructor(composeScreen: ComposeScreen<*>, useUnmergedTree : Boolean = false, function: ViewBuilder.() -> Unit) {
+        nodeInteraction = ViewBuilder(composeScreen.composeTestRule, useUnmergedTree).apply(function).nodeInteraction
     }
 }

--- a/compose/src/main/kotlin/io/github/kakaocup/compose/node/ViewBuilder.kt
+++ b/compose/src/main/kotlin/io/github/kakaocup/compose/node/ViewBuilder.kt
@@ -4,11 +4,12 @@ import androidx.compose.ui.semantics.*
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.text.input.ImeAction
+import io.github.kakaocup.compose.node.matchers.isAny
 
-class ViewBuilder(composeTestRule: AndroidComposeTestRule<*, *>) {
+class ViewBuilder(composeTestRule: AndroidComposeTestRule<*, *>, useUnmergedTree: Boolean = false) {
 
     private var semanticsNodeInteractionCollection: SemanticsNodeInteractionCollection =
-        composeTestRule.onRoot().onChildren()
+        composeTestRule.onAllNodes(isAny(), useUnmergedTree)
 
     val nodeInteraction: SemanticsNodeInteraction
         get() = semanticsNodeInteractionCollection[position]
@@ -37,6 +38,7 @@ class ViewBuilder(composeTestRule: AndroidComposeTestRule<*, *>) {
      * @see SemanticsProperties.ToggleableState
      */
     fun isOn() = addFilter(androidx.compose.ui.test.isOn())
+
     /**
      * Returns whether the node is not toggled.
      *
@@ -99,6 +101,7 @@ class ViewBuilder(composeTestRule: AndroidComposeTestRule<*, *>) {
      * @see SemanticsActions.OnClick
      */
     fun hasClickAction() = addFilter(androidx.compose.ui.test.hasClickAction())
+
     /**
      * Return whether the node has no semantics click action defined.
      *
@@ -154,6 +157,7 @@ class ViewBuilder(composeTestRule: AndroidComposeTestRule<*, *>) {
     fun hasContentDescriptionExactly(
         vararg values: String
     ) = addFilter(androidx.compose.ui.test.hasContentDescriptionExactly(values = values))
+
     /**
      * Returns whether the node's text contains the given [text].
      *
@@ -287,7 +291,6 @@ class ViewBuilder(composeTestRule: AndroidComposeTestRule<*, *>) {
      */
     @ExperimentalTestApi
     fun hasScrollToKeyAction() = addFilter(androidx.compose.ui.test.hasScrollToKeyAction())
-
 
     /**
      * Return whether the node is the root semantics node.

--- a/compose/src/main/kotlin/io/github/kakaocup/compose/node/extensions/ScreenExtension.kt
+++ b/compose/src/main/kotlin/io/github/kakaocup/compose/node/extensions/ScreenExtension.kt
@@ -4,4 +4,5 @@ import io.github.kakaocup.compose.node.KNode
 import io.github.kakaocup.compose.node.ViewBuilder
 import io.github.kakaocup.compose.screen.ComposeScreen
 
-fun ComposeScreen<*>.onNode(function: ViewBuilder.() -> Unit) = KNode(this, function)
+fun ComposeScreen<*>.onNode(useUnmergedTree : Boolean = false,
+                            function: ViewBuilder.() -> Unit) = KNode(this, useUnmergedTree, function)

--- a/compose/src/main/kotlin/io/github/kakaocup/compose/node/matchers/CustomMatchers.kt
+++ b/compose/src/main/kotlin/io/github/kakaocup/compose/node/matchers/CustomMatchers.kt
@@ -1,0 +1,8 @@
+package io.github.kakaocup.compose.node.matchers
+
+import androidx.compose.ui.test.SemanticsMatcher
+
+/**
+ * Matcher that returns any node in the hierarchy.
+ */
+internal fun isAny() = SemanticsMatcher("isAny") { true }

--- a/sample/src/androidTest/java/io/github/kakaocup/compose/ExampleInstrumentedTest.kt
+++ b/sample/src/androidTest/java/io/github/kakaocup/compose/ExampleInstrumentedTest.kt
@@ -36,4 +36,18 @@ class ExampleInstrumentedTest {
             }
         }
     }
+
+    @Test
+    fun unmergedTreeTest() {
+        onComposeScreen<MainActivityScreen>(composeTestRule) {
+            myOutlinedButtonText {
+                assertDoesNotExist()
+            }
+
+            unmergedTreeOutlinedButtonText {
+                assertExists()
+            }
+        }
+    }
+
 }

--- a/sample/src/androidTest/java/io/github/kakaocup/compose/MainActivityScreen.kt
+++ b/sample/src/androidTest/java/io/github/kakaocup/compose/MainActivityScreen.kt
@@ -21,4 +21,12 @@ class MainActivityScreen(composeTestRule: AndroidComposeTestRule<*, *>) :
         hasTestTag("myTestButton")
         hasText("Button 1")
     }
+
+    val myOutlinedButtonText = KNode(this) {
+        hasTestTag("myTestOutlinedButtonContent")
+    }
+
+    val unmergedTreeOutlinedButtonText = KNode(this, useUnmergedTree = true) {
+        hasTestTag("myTestOutlinedButtonContent")
+    }
 }

--- a/sample/src/main/java/io/github/kakaocup/compose/MainActivity.kt
+++ b/sample/src/main/java/io/github/kakaocup/compose/MainActivity.kt
@@ -5,8 +5,11 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Button
+import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 
@@ -26,6 +29,12 @@ class MainActivity : AppCompatActivity() {
                 }, onClick = {
 
                 }, modifier = Modifier.semantics { testTag = "myTestButton" })
+
+                OutlinedButton(content = {
+                    Text(modifier = Modifier.testTag("myTestOutlinedButtonContent"), text = "Button 2")
+                }, onClick = {
+
+                }, modifier = Modifier.testTag("myTestOutlinedButton"))
             }
         }
     }


### PR DESCRIPTION
Resolves #14 

This PR includes support for `useUnmergedTree` over the nodes inside the `ComposeTestRule`. I have made some minor changes over the constructors of `KNode`, and `ViewBuilder` to include this parameter.
However the current implementation using `composeTestRule.onRoot(useUnmergedTree).onChildren()` was only returning the children of the root and not the nested ones. No matter if `useUnmergedTree` was used or not. 

I think that the `onChildren()` method from Compose should take this into account but it's not doing it. The fix I have included makes use of the `onAllNodes()` method with a custom `SemanticMatcher` that takes any node inside it. I have looked into the `onChildren()` implementation together with how the framework looks for the children on the nodes, but I have not found a better solution. If you find other way to do it, please let me know or suggest a change on the PR!

Thank you so much! 

