### PR TITLE
Enhancement - Add support for checking the length of a lazy list

### DIFF
--- a/compose/src/main/kotlin/io/github/kakaocup/compose/node/assertion/LazyListNodeAssertions.kt
+++ b/compose/src/main/kotlin/io/github/kakaocup/compose/node/assertion/LazyListNodeAssertions.kt
@@ -1,0 +1,27 @@
+package io.github.kakaocup.compose.node.assertion
+
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+
+interface LazyListNodeAssertions : NodeAssertions {
+    val lengthSemanticsPropertyKey: SemanticsPropertyKey<Int>
+
+    /**
+     * Asserts that the lazy list length contains the given [length].
+     *
+     * Throws [AssertionError] if the lazy list's length value is not equal to `length`.
+     * Throws [IllegalStateException] if the lazy list does not contain the [lengthSemanticsPropertyKey] modifier.
+     */
+    fun assertLengthEquals(length: Int) {
+        delegate.check(NodeAssertions.ComposeBaseAssertionType.ASSERT_VALUE_EQUALS) { assert(hasLazyListLength(length)) }
+    }
+
+    private fun hasLazyListLength(length: Int): SemanticsMatcher = SemanticsMatcher(
+        "The length of the lazy list is expected to be ${length}, but the actual size is different"
+    ) { node ->
+        val actualLength = node.config.getOrNull(lengthSemanticsPropertyKey) ?: error("Lazy list does not contain $lengthSemanticsPropertyKey modifier")
+        return@SemanticsMatcher actualLength == length
+    }
+}

--- a/compose/src/main/kotlin/io/github/kakaocup/compose/node/element/lazylist/KLazyListNode.kt
+++ b/compose/src/main/kotlin/io/github/kakaocup/compose/node/element/lazylist/KLazyListNode.kt
@@ -1,11 +1,13 @@
 package io.github.kakaocup.compose.node.element.lazylist
 
+import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.onChildren
+import io.github.kakaocup.compose.node.assertion.LazyListNodeAssertions
 import io.github.kakaocup.compose.node.builder.NodeMatcher
 import io.github.kakaocup.compose.node.builder.ViewBuilder
 import io.github.kakaocup.compose.node.core.BaseNode
@@ -17,8 +19,10 @@ class KLazyListNode(
     semanticsProvider: SemanticsNodeInteractionsProvider,
     nodeMatcher: NodeMatcher,
     itemTypeBuilder: KLazyListItemBuilder.() -> Unit,
-    val positionMatcher: (position: Int) -> SemanticsMatcher
-) : BaseNode<KLazyListNode>(semanticsProvider, nodeMatcher) {
+    val positionMatcher: (position: Int) -> SemanticsMatcher,
+    override val lengthSemanticsPropertyKey: SemanticsPropertyKey<Int>,
+) : BaseNode<KLazyListNode>(semanticsProvider, nodeMatcher),
+    LazyListNodeAssertions {
     val semanticsMatcher = nodeMatcher.matcher
     val itemTypes = KLazyListItemBuilder().apply(itemTypeBuilder).itemTypes
 
@@ -36,12 +40,14 @@ class KLazyListNode(
         semanticsProvider: SemanticsNodeInteractionsProvider,
         viewBuilderAction: ViewBuilder.() -> Unit,
         itemTypeBuilder: KLazyListItemBuilder.() -> Unit,
-        positionMatcher: (position: Int) -> SemanticsMatcher
+        positionMatcher: (position: Int) -> SemanticsMatcher,
+        lengthSemanticsPropertyKey: SemanticsPropertyKey<Int>
     ) : this(
         semanticsProvider = semanticsProvider,
         nodeMatcher = ViewBuilder().apply(viewBuilderAction).build(),
         itemTypeBuilder = itemTypeBuilder,
-        positionMatcher = positionMatcher
+        positionMatcher = positionMatcher,
+        lengthSemanticsPropertyKey = lengthSemanticsPropertyKey
     )
 
     /**

--- a/sample/src/androidTest/java/io/github/kakaocup/compose/screen/LazyListScreen.kt
+++ b/sample/src/androidTest/java/io/github/kakaocup/compose/screen/LazyListScreen.kt
@@ -3,11 +3,12 @@ package io.github.kakaocup.compose.screen
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
-import io.github.kakaocup.compose.sample.LazyListItemPosition
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.github.kakaocup.compose.node.element.KNode
 import io.github.kakaocup.compose.node.element.lazylist.KLazyListItemNode
 import io.github.kakaocup.compose.node.element.lazylist.KLazyListNode
+import io.github.kakaocup.compose.sample.LazyListItemPositionSemantics
+import io.github.kakaocup.compose.sample.LazyListLengthSemantics
 
 class LazyListScreen(semanticsProvider: SemanticsNodeInteractionsProvider) : ComposeScreen<LazyListScreen>(
     semanticsProvider = semanticsProvider,
@@ -20,8 +21,11 @@ class LazyListScreen(semanticsProvider: SemanticsNodeInteractionsProvider) : Com
             itemType(::LazyListItemNode)
             itemType(::LazyListHeaderNode)
         },
-        positionMatcher = { position -> SemanticsMatcher.expectValue(LazyListItemPosition, position) }
+        positionMatcher = { position -> SemanticsMatcher.expectValue(LazyListItemPositionSemantics, position) },
+        lengthSemanticsPropertyKey = LazyListLengthSemantics
     )
+
+    val pullToRefresh = KNode(semanticsProvider) { hasTestTag("PullToRefresh") }
 }
 
 class LazyListItemNode(

--- a/sample/src/androidTest/java/io/github/kakaocup/compose/test/LazyListTest.kt
+++ b/sample/src/androidTest/java/io/github/kakaocup/compose/test/LazyListTest.kt
@@ -3,6 +3,7 @@ package io.github.kakaocup.compose.test
 import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.swipeDown
 import io.github.kakaocup.compose.sample.LazyListScreen
 import io.github.kakaocup.compose.node.element.ComposeScreen.Companion.onComposeScreen
 import io.github.kakaocup.compose.screen.LazyListHeaderNode
@@ -26,7 +27,12 @@ class LazyListTest {
         }
 
         onComposeScreen<LazyListScreen>(composeTestRule) {
+            list.assertLengthEquals(0)
+            pullToRefresh.performTouchInput {
+                swipeDown(startY = 200f)
+            }
             list {
+                assertLengthEquals(33)
                 firstChild<LazyListHeaderNode> {
                     title.assertTextEquals("Items from 1 to 10")
                 }
@@ -50,6 +56,11 @@ class LazyListTest {
                     assertTextEquals("Item 30")
                 }
             }
+            list.performScrollToIndex(0)
+            pullToRefresh.performTouchInput {
+                swipeDown(startY = 200f)
+            }
+            list.assertLengthEquals(34)
         }
     }
 }


### PR DESCRIPTION
I tried to implement it using compose.foundation, but I couldn’t get access to the variable that is responsible for the length of the list.

If you are interested, itemProviderLambda is created in the package androidx.compose.foundation.lazy in fun LazyList, which contains knowledge about the size of the list. But I couldn't find a way to get this information.